### PR TITLE
Remove wechaty-puppet from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-padlocal",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Puppet PadLocal for Wechaty",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
     "tslint-config-prettier": "^1.18.0",
     "tstest": "^0.4.10",
     "wechaty": "^0.50.7",
-    "wechaty-puppet": "^0.33.3"
+    "wechaty-puppet": "^0.34.1"
   },
   "peerDependencies": {
-    "wechaty-puppet": ">=0.33.3"
+    "wechaty-puppet": ">=0.34.1"
   },
   "dependencies": {
     "@types/fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -68,10 +68,11 @@
     "tsc-watch": "^4.2.9",
     "tslint-config-prettier": "^1.18.0",
     "tstest": "^0.4.10",
-    "wechaty": "^0.50.7"
+    "wechaty": "^0.50.7",
+    "wechaty-puppet": "^0.33.3"
   },
   "peerDependencies": {
-    "wechaty-puppet": "*"
+    "wechaty-puppet": ">=0.33.3"
   },
   "dependencies": {
     "@types/fs-extra": "^9.0.1",
@@ -91,7 +92,6 @@
     "state-switch": "^0.6.18",
     "typed-emitter": "^1.2.0",
     "watchdog": "^0.8.17",
-    "wechaty-puppet": "^0.33.3",
     "xml2js": "^0.4.23"
   },
   "jest": {


### PR DESCRIPTION
It should be placed into devDependencies instead.

See: https://github.com/wechaty/wechaty-puppet/issues/125

Or it will cause problems when we use newer Wechaty modules.

Link to https://github.com/wechaty/puppet-services/issues/84